### PR TITLE
Capture errors 

### DIFF
--- a/__mocks__/raven.js
+++ b/__mocks__/raven.js
@@ -4,6 +4,11 @@ const client = {
       cb();
     }
   }),
+  captureException: jest.fn((data, extra, cb) => {
+    if (typeof cb === 'function') {
+      cb();
+    }
+  }),
   install: jest.fn(),
 };
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -141,7 +141,8 @@ describe('GoodSentry', () => {
 
     const events = [
       { error, tags: ['error', 'application'] },
-      { data: { error, user: 'doe' }, tags: ['error', 'application'] }
+      { data: { error, user: 'doe' }, tags: ['error', 'application'] },
+      { data: { err: error }, tags: ['error', 'application'] }
     ];
 
     for (let i = 0; i < events.length; ++i) {
@@ -176,6 +177,15 @@ describe('GoodSentry', () => {
         extra: {
           event: 'log',
           user: 'doe',
+        },
+        tags: { application: true },
+      });
+
+      expect(client.captureException.mock.calls[2][0]).toBe(error);
+      expect(client.captureException.mock.calls[2][1]).toEqual({
+        level: 'error',
+        extra: {
+          event: 'log'
         },
         tags: { application: true },
       });

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,17 @@ class GoodSentry extends Stream.Writable {
       },
     };
 
-    this._client.captureMessage(data.data, additionalData, () => cb());
+    const error = data.error || (data.data && data.data.error);
+    if (error) {
+      if (data.data) {
+        Object.assign(additionalData.extra, data.data);
+        delete additionalData.extra.error;
+      }
+      this._client.captureException(error, additionalData, cb());
+    }
+    else {
+      this._client.captureMessage(data.data, additionalData, cb());
+    }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,16 +63,19 @@ class GoodSentry extends Stream.Writable {
       },
     };
 
-    const error = data.error || (data.data && data.data.error);
+    const error = data.error || (data.data && (data.data.error || data.data.err));
     if (error) {
       if (data.data) {
-        Object.assign(additionalData.extra, data.data);
-        delete additionalData.extra.error;
+        Object.keys(data.data).forEach((key) => {
+          if (data.data[key] !== error) {
+            additionalData.extra[key] = data.data[key];
+          }
+        });
       }
-      this._client.captureException(error, additionalData, cb());
+      this._client.captureException(error, additionalData, () => cb());
     }
     else {
-      this._client.captureMessage(data.data, additionalData, cb());
+      this._client.captureMessage(data.data, additionalData, () => cb());
     }
   }
 }


### PR DESCRIPTION
If an error is being logged then use `captureException` to capture it. 

Two cases this tries to deal with: 1) as per [hapi-good docs](https://github.com/hapijs/good/blob/master/API.md) there are a couple cases where you only get `data.error` and no `data.data`: request error events, `log` calls with an Error object as the data. In this case all you get in sentry is undefined
2) data is an object and either `error` or `err` properties are set - in this case pass the error to sentry and send the other data keys as extra data. This is just a way to allow additional data to be logged along with the error itself



